### PR TITLE
Log all applications on startup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,10 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="fi.idk.kotivaloscreenshame">
 
-    <uses-permission android:name="android.permission.PACKAGE_USAGE_STATS" />
+    <uses-permission android:name="android.permission.PACKAGE_USAGE_STATS"
+        tools:ignore="ProtectedPermissions" />
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
+        tools:ignore="QueryAllPackagesPermission" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
@@ -19,7 +22,7 @@
         <service
             android:name=".AppUsageService"
             android:enabled="true"
-            android:exported="true"></service>
+            android:exported="true"/>
 
         <activity
             android:name=".MainActivity"

--- a/app/src/main/java/fi/idk/kotivaloscreenshame/AppListHelper.kt
+++ b/app/src/main/java/fi/idk/kotivaloscreenshame/AppListHelper.kt
@@ -1,0 +1,29 @@
+package fi.idk.kotivaloscreenshame
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import android.graphics.drawable.Drawable
+
+class AppHelper(private val context: Context) {
+    fun getApps(): List<ApplicationInfo> {
+        val packageManager: PackageManager = context.packageManager
+        val installedApps = packageManager.getInstalledApplications(PackageManager.GET_META_DATA)
+        // Exclude system apps
+        return installedApps.filter { app ->
+            (app.flags and ApplicationInfo.FLAG_SYSTEM) == 0
+        }
+    }
+
+    fun getAppName(app: ApplicationInfo): String {
+        val packageManager: PackageManager = context.packageManager
+        val appName = packageManager.getApplicationLabel(app).toString()
+        return appName
+    }
+
+    fun getAppIcon(app: ApplicationInfo): Drawable {
+        val packageManager: PackageManager = context.packageManager
+        val appIcon = packageManager.getApplicationIcon(app)
+        return appIcon
+    }
+}

--- a/app/src/main/java/fi/idk/kotivaloscreenshame/AppUsageService.kt
+++ b/app/src/main/java/fi/idk/kotivaloscreenshame/AppUsageService.kt
@@ -21,10 +21,22 @@ class AppUsageService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        logApplications()
         Handler(Looper.getMainLooper()).post {
             logUsageEvents()
         }
         return START_STICKY
+    }
+
+    private fun logApplications() {
+        val appHelper = AppHelper(this)
+        val apps = appHelper.getApps()
+
+        for (app in apps) {
+            val label = appHelper.getAppName(app)
+            val packageName = app.packageName
+            Log.i("AppUsageService", "App: $label, Package: $packageName")
+        }
     }
 
     private fun logUsageEvents() {


### PR DESCRIPTION
Lists all non-system applications on startup. The helper class has methods to retrieve the app's label and icon. The package name acts as an identifier and can be matched with the app usage stats.